### PR TITLE
Add custom WHERE condition to query

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -38,6 +38,11 @@ function PgRestify(config, postInitFunction) {
 
     self.executeWithHooks(req, res, next, 'getList', function(dbClient, next) {
 
+      // Skip if res.pgRestifyResponseBody is not empty, we assume preHook already generated content
+      if (res.pgRestifyResponseBody){
+        return next();
+      }
+
       var table = self.convertResourceToTable(req.params.resource);
 
       self.validateTable(table, function(err) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -112,11 +112,15 @@ function PgRestify(config, postInitFunction) {
 
         var query = sql
                     .select()
-                    .from(table)
-                    .orderBy(orderBy)
-                    .limit(pageSize)
-                    .offset((page-1)*pageSize)
-                    .toString();
+                    .from(table);
+        if (res.pgRestifyWhere){
+          query = query.where(res.pgRestifyWhere);
+        }
+        query = query
+                .orderBy(orderBy)
+                .limit(pageSize)
+                .offset((page-1)*pageSize)
+                .toString();
 
         dbClient.query(query, function(err, result) {
 

--- a/readme.md
+++ b/readme.md
@@ -253,6 +253,27 @@ hooks.addPreHookForAllResources('get', function(req, res, dbClient, next) {
 
 });
 
+// One more example for custom where
+// with this pre-hook you can call: <api-endpoint>/api/v1/message?read=0&pageSize=10
+// Will generate query with {read: 0}
+hooks.addPreHookForAllResources('getList', function(req, res, dbClient, next){
+
+  res.pgRestifyWhere = {};
+  for (key in req.query){
+    switch (key){
+      case 'pageSize':
+      case 'page':
+      case 'orderBy':
+      case 'orderByDesc':
+        break;
+      default:
+        where[key] = req.query[key];
+    }
+  }
+  return next();
+
+});
+
 // You can also specify a specific resource and event type to apply a hook to.
 hooks.addPreHookForResource('delete', 'user-alert-messages', function(req, res, dbClient, next) {
 

--- a/readme.md
+++ b/readme.md
@@ -267,7 +267,7 @@ hooks.addPreHookForAllResources('getList', function(req, res, dbClient, next){
       case 'orderByDesc':
         break;
       default:
-        where[key] = req.query[key];
+        res.pgRestifyWhere[key] = req.query[key];
     }
   }
   return next();


### PR DESCRIPTION
Hi, nice library.
Can review and upload this small feature, which permits to skip the query in case if there is already `res.pgRestifyResponseBody`.
Also you can add custom **WHERE** condition to query with preHooks