### PR TITLE
Multiple improvements for Insert and hooks.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21,6 +21,7 @@ function PgRestify(config, postInitFunction) {
   this.convertFieldToColumn = config.convertFieldToColumn || defaultConvertFieldToColumn;
   this.convertColumnToField = config.convertColumnToField || defaultConvertColumnToField;
   this.hooks = config.hooks || new exports.Hooks();
+  this.hooks.parent = this;
   this.tableIdColumns = config.tableIdColumns || {};
   var self = this;
 
@@ -39,7 +40,7 @@ function PgRestify(config, postInitFunction) {
 
     self.executeWithHooks(req, res, next, 'getList', function(dbClient, next) {
 
-      // Skip if res.pgRestifyResponseBody is not empty, we assume preHook already generated content
+      // Skip if res.pgRestifyResponseBody is not empty, we assume preHook already generated response body
       if (res.pgRestifyResponseBody){
         return next();
       }
@@ -217,6 +218,11 @@ function PgRestify(config, postInitFunction) {
   server.post(this.basePath + '/:resource', function handlePost(req, res, next) {
 
     self.executeWithHooks(req, res, next, 'post', function(dbClient, next) {
+
+      // Skip if res.pgRestifyResponseBody is not empty, we assume preHook already did the magic and generated response body
+      if (res.pgRestifyResponseBody){
+        return next();
+      }
 
       var table = self.convertResourceToTable(req.params.resource);
       var data = self.convertFieldsToColumns(req.body);

--- a/lib/index.js
+++ b/lib/index.js
@@ -276,7 +276,7 @@ function PgRestify(config, postInitFunction) {
 
             res.status(200);
 
-            res.send(JSON.stringify(result));
+            res.pgRestifyResponseBody = result;
 
             return next();
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -27,7 +27,7 @@ function PgRestify(config, postInitFunction) {
 
   var server = config.server;
   this.server = server;
-  server.use(config.bodyParser || restify.plugins.bodyParser());
+  server.use(restify.plugins.bodyParser());
   server.use(restify.plugins.queryParser());
   server.use(restify.plugins.requestLogger({
     serializers: {

--- a/lib/index.js
+++ b/lib/index.js
@@ -276,6 +276,8 @@ function PgRestify(config, postInitFunction) {
 
             res.status(200);
 
+            res.send(JSON.stringify(result));
+
             return next();
 
           }

--- a/lib/index.js
+++ b/lib/index.js
@@ -237,6 +237,9 @@ function PgRestify(config, postInitFunction) {
           var location = ((req.isSecure()) ? 'https' : 'http') +
           '://' + req.headers.host + req.url + '/' + result.rows[0][self.tableIdColumns[table] || 'id'];
           res.setHeader('location', location);
+
+          res.pgRestifyResponseBody = result;
+
           res.status(201);
 
           return next();

--- a/lib/index.js
+++ b/lib/index.js
@@ -27,7 +27,7 @@ function PgRestify(config, postInitFunction) {
 
   var server = config.server;
   this.server = server;
-  server.use(restify.plugins.bodyParser());
+  server.use(config.bodyParser || restify.plugins.bodyParser());
   server.use(restify.plugins.queryParser());
   server.use(restify.plugins.requestLogger({
     serializers: {

--- a/readme.md
+++ b/readme.md
@@ -334,6 +334,7 @@ to the post-initialization function.
 | convertFieldToColumn | userName => user_name | A function which transforms a field from submitted JSON into a column name in the database. |
 | convertColumnToField | user_name => userName | A function which transforms a column name from the database into a field name in returned JSON. |
 | tableIdColumns | {} | A map of table name to column name to use for the id field. If the table is not defined the default value of 'id' will be used for the column name. |
+| bodyParser | undefined | Customized bodyParser, the default one will be used otherwise |
 
 
 ### Instance functions

--- a/readme.md
+++ b/readme.md
@@ -334,7 +334,6 @@ to the post-initialization function.
 | convertFieldToColumn | userName => user_name | A function which transforms a field from submitted JSON into a column name in the database. |
 | convertColumnToField | user_name => userName | A function which transforms a column name from the database into a field name in returned JSON. |
 | tableIdColumns | {} | A map of table name to column name to use for the id field. If the table is not defined the default value of 'id' will be used for the column name. |
-| bodyParser | undefined | Customized bodyParser, the default one will be used otherwise |
 
 
 ### Instance functions

--- a/readme.md
+++ b/readme.md
@@ -81,8 +81,35 @@ curl -X POST \
 
 **Response**
 ```
+# Header:
 HTTP 201 Created
 location: http://127.0.0.1:8080/api/generic/user-alert-messages/1
+# Body (JSON pg SQL INSERT result) example:
+{
+    "command": "INSERT",
+    "rowCount": 1,
+    "oid": 0,
+    "rows": [
+        {
+            "id": 1
+        }
+    ],
+    "fields": [
+        {
+            "name": "id",
+            "tableID": 17558,
+            "columnID": 1,
+            "dataTypeID": 23,
+            "dataTypeSize": 4,
+            "dataTypeModifier": -1,
+            "format": "text"
+        }
+    ],
+    "_parsers": [
+        null
+    ],
+    "rowAsArray": false
+}
 ```
 
 ---


### PR DESCRIPTION
* Added possibility to fill the response body from hook
* Return Inserted row response as JSON in body
* Open access to parent (pgRestigy) instance from inside the hooks, so pgRestify helpers or other methods could be used.